### PR TITLE
test->prod: Add docker multiplatform build for build and push workflow (#123)

### DIFF
--- a/.github/workflows/build-and-push-docker-hub.yaml
+++ b/.github/workflows/build-and-push-docker-hub.yaml
@@ -37,17 +37,27 @@ jobs:
       - name: Copy jar to dockerfiles
         run: cp ./target/*.jar .github/dockerfiles/app.jar
 
-      - name: Get shortened git hash
-        run: |
-          git_hash=$(git rev-parse --short "$GITHUB_SHA")
-          echo "git_hash=$git_hash" >> $GITHUB_ENV
+      - name: Extract git hash
+        id: get_hash
+        run: echo "::set-output name=hash::$(git rev-parse --short HEAD)"
 
-      - name: Build Docker image
-        run: docker build --file Dockerfile_jms_be -t vladokat/jms-be:$git_hash .
-        working-directory: .github/dockerfiles/
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-      - name: Log in to Docker Hub
-        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push Docker image to Docker Hub
-        run: docker push vladokat/jms-be:$git_hash
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .github/dockerfiles
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: .github/dockerfiles/Dockerfile_jms_be
+          tags: vladokat/jms-be:${{ steps.get_hash.outputs.hash }}


### PR DESCRIPTION
* feat: try multiplatform build on push

* feat: try another tag pass

* feat: git hash with command

* feat: try another git hash setting

* fix: docker file context in build-push-docker-hub

* fix: path to dockerfile in build-push-docker-hub

* fix: path to dockerfile to include .github/dockerfiles

* fix: change context of build and push step

* fix: bring back push to docker hub on main only